### PR TITLE
feat(endpoint): expose createdAt and updatedAt fields in /dyan/endpoints API

### DIFF
--- a/apps/backend/src/endpoint/endpoint.controller.ts
+++ b/apps/backend/src/endpoint/endpoint.controller.ts
@@ -27,6 +27,8 @@ export class EndpointController {
         path: true,
         method: true,
         language: true,
+        createdAt:true,
+        updatedAt:true
       },
     });
     return endpoints;


### PR DESCRIPTION

### Description

This PR updates the `/dyan/endpoints` API to include the `createdAt` and `updatedAt` timestamp fields in its response. This change allows clients to sort and audit endpoints based on their creation and update times.

### Changes

- Updated the `getAllEndpoints` method in `EndpointController` to select and return `createdAt` and `updatedAt` fields.
- No changes were needed to the Prisma schema, as the fields already existed.


Closes #9

